### PR TITLE
Filter out lock objects to make sure the alarm status is sent correctly

### DIFF
--- a/verisure-api.js
+++ b/verisure-api.js
@@ -165,7 +165,14 @@ function fetchSmartplugData() {
 function parseAlarmData ( data ) {
 	"use strict";
 
-	data = filterByKeys( data[ 0 ], config.alarmFields );
+	// Find the alarm status object (filter out any lock status objects)
+  if ( Array.isArray ( data )) {
+    data = data.find(function(obj){
+      return obj.type == 'ARM_STATE'
+    });
+  }
+
+  data = filterByKeys( data, config.alarmFields );
 
 	setTimeout( pollAlarmStatus, alarmFetchTimeout );
 


### PR DESCRIPTION
Added filtering of the returned alarm status objects to make sure that any lock objects reported does not mess upp the status.
